### PR TITLE
RP-9: remove role=option

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ The Slide component is a container with an intrinsic ratio computed by the Carou
 | innerTag | string | 'div' | No | The inner HTML element for each Slide. |
 | onBlur | [function&#124;null] | null | No | Optional callback function that is called after the internal onBlur function is called. It is passed the React synthetic event |
 | onFocus | [function&#124;null] | null | No | Optional callback function that is called after the internal onFocus function is called. It is passed the React synthetic event |
+| role | [string&#124;null] | null | No | The ARIA role of the root HTML element |
 | tabIndex | [number&#124;null] | null | No | When null, the Carousel will set this automatically.  99.9% of the time, you're going to want to leave this alone and let the carousel handle tabIndex automatically. |
 | tag | string | 'li' | No | The root HTML element for each Slide. |
 

--- a/src/Slide/Slide.jsx
+++ b/src/Slide/Slide.jsx
@@ -97,6 +97,7 @@ const Slide = class Slide extends React.PureComponent {
       onBlur,
       onFocus,
       orientation,
+      role,
       slideSize,
       style,
       tabIndex,
@@ -146,7 +147,7 @@ const Slide = class Slide extends React.PureComponent {
         ref={(el) => { this.tagRef = el; }}
         tabIndex={newTabIndex}
         aria-selected={this.isVisible()}
-        role="option"
+        role={role}
         onFocus={this.handleOnFocus}
         onBlur={this.handleOnBlur}
         className={newClassName}

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -29,6 +29,7 @@ interface SlideProps {
   readonly onFocus?: () => void;
   readonly tabIndex?: number;
   readonly tag?: string;
+  readonly role?: string;
 }
 type SlideInterface = React.ComponentClass<SlideProps>;
 /**

--- a/typings/carouselElements.d.ts
+++ b/typings/carouselElements.d.ts
@@ -1,38 +1,36 @@
-import * as React from 'react'
+import * as React from "react";
 
 interface SliderProps {
-  readonly children: React.ReactNode
-  readonly className?: string
-  readonly classNameAnimation?: string
-  readonly classNameTray?: string
-  readonly classNameTrayWrap?: string
-  readonly moveThreshold?: number,
-  readonly onMasterSpinner?: () => void
-  readonly style?: {}
-  readonly spinner?: () => void
-  readonly trayTag?: string
+  readonly children: React.ReactNode;
+  readonly className?: string;
+  readonly classNameAnimation?: string;
+  readonly classNameTray?: string;
+  readonly classNameTrayWrap?: string;
+  readonly moveThreshold?: number;
+  readonly onMasterSpinner?: () => void;
+  readonly style?: {};
+  readonly spinner?: () => void;
+  readonly trayTag?: string;
 }
-type SliderInterface = React.ComponentClass<SliderProps>
+type SliderInterface = React.ComponentClass<SliderProps>;
 /**
  * A Slider is a viewport that masks slides. The Slider component must wrap one or more Slide components.
  */
-declare const Slider: SliderInterface
-
-
+declare const Slider: SliderInterface;
 
 interface SlideProps {
-  readonly className?: string
-  readonly classNameHidden?: string
-  readonly classNameVisible?: string
-  readonly index: number
-  readonly innerClassName?: string
-  readonly innerTag?: string
-  readonly onBlur?: () => void
-  readonly onFocus?: () => void
-  readonly tabIndex?: number
-  readonly tag?: string
+  readonly className?: string;
+  readonly classNameHidden?: string;
+  readonly classNameVisible?: string;
+  readonly index: number;
+  readonly innerClassName?: string;
+  readonly innerTag?: string;
+  readonly onBlur?: () => void;
+  readonly onFocus?: () => void;
+  readonly tabIndex?: number;
+  readonly tag?: string;
 }
-type SlideInterface = React.ComponentClass<SlideProps>
+type SlideInterface = React.ComponentClass<SlideProps>;
 /**
  * The Slide component is a container with an intrinsic ratio computed by the
  * CarouselProvider naturalSlideWidth and naturalSlideHeight properties.
@@ -41,136 +39,118 @@ type SlideInterface = React.ComponentClass<SlideProps>
  * Slide components also contain a div that acts as an aria compliant focus ring when
  * the Slide receives focus either by using a keyboard tab, mouse click, or touch.
  */
-declare const Slide: SlideInterface
-
-
+declare const Slide: SlideInterface;
 
 interface ImageWithZoomProps {
-  readonly src: string
-  readonly srcZoomed?: string
-  readonly tag?: string
+  readonly src: string;
+  readonly srcZoomed?: string;
+  readonly tag?: string;
 }
-type ImageWithZoomInterface = React.ComponentClass<ImageWithZoomProps>
-declare const ImageWithZoom: ImageWithZoomInterface
-
-
+type ImageWithZoomInterface = React.ComponentClass<ImageWithZoomProps>;
+declare const ImageWithZoom: ImageWithZoomInterface;
 
 interface ImageProps {
-  readonly alt?: string
-  readonly children?: React.ReactNode
-  readonly className?: string
-  readonly hasMasterSpinner: boolean
-  readonly isBgImage?: boolean
-  readonly onError?: () => void
-  readonly onLoad?: () => void
-  readonly renderError?: () => void
-  readonly renderLoading?: () => void
-  readonly src: string
+  readonly alt?: string;
+  readonly children?: React.ReactNode;
+  readonly className?: string;
+  readonly hasMasterSpinner: boolean;
+  readonly isBgImage?: boolean;
+  readonly onError?: () => void;
+  readonly onLoad?: () => void;
+  readonly renderError?: () => void;
+  readonly renderLoading?: () => void;
+  readonly src: string;
   readonly style?: {
-    readonly [key: string]: string
-  }
-  readonly tag?: string
+    readonly [key: string]: string;
+  };
+  readonly tag?: string;
 }
-type ImageInterface = React.ComponentClass<ImageProps>
-declare const Image: ImageInterface
-
-
+type ImageInterface = React.ComponentClass<ImageProps>;
+declare const Image: ImageInterface;
 
 interface DotGroupProps {
-  readonly children?: React.ReactNode
-  readonly className?: string
-  readonly dotNumbers?: boolean
+  readonly children?: React.ReactNode;
+  readonly className?: string;
+  readonly dotNumbers?: boolean;
 }
-type DotGroupInterface = React.ComponentClass<DotGroupProps>
+type DotGroupInterface = React.ComponentClass<DotGroupProps>;
 /**
  * A compound component that creates a bunch of Dot's automatically for you.
  */
-declare const DotGroup: DotGroupInterface
-
-
+declare const DotGroup: DotGroupInterface;
 
 interface DotProps {
-  readonly children: React.ReactChild
-  readonly className?: string
-  readonly disabled?: boolean
-  readonly onClick?: () => void
-  readonly slide: number
+  readonly children: React.ReactChild;
+  readonly className?: string;
+  readonly disabled?: boolean;
+  readonly onClick?: () => void;
+  readonly slide: number;
 }
-type DotInterface = React.ComponentClass<DotProps>
+type DotInterface = React.ComponentClass<DotProps>;
 /**
  * A Dot component is a HTML button. Dots directly correlate to slides. Clicking on a dot causes it's correlating slide to scroll into the left-most visible slot of slider. The dots for currently visible slides cause are disabled. You can override the auto-disable feature by setting disabled to false (see table below)
  */
-declare const Dot: DotInterface
-
-
+declare const Dot: DotInterface;
 
 interface ButtonNextProps {
-  readonly children: React.ReactChild
-  readonly className?: string
-  readonly disabled?: boolean
-  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly children: React.ReactChild;
+  readonly className?: string;
+  readonly disabled?: boolean;
+  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
-type ButtonNextInterface = React.ComponentClass<ButtonNextProps>
+type ButtonNextInterface = React.ComponentClass<ButtonNextProps>;
 /**
  * A button for moving the slider forwards. Forwards on a horizontal carousel means "move to the right". Backwards on a vertical carousel means "move to the bottom". The slider will traverse an amount of slides determined by the step property of CarouselProvider.
  */
-declare const ButtonNext: ButtonNextInterface
-
-
+declare const ButtonNext: ButtonNextInterface;
 
 interface ButtonBackProps {
-  readonly children: React.ReactChild
-  readonly className?: string
-  readonly disabled?: boolean
-  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly children: React.ReactChild;
+  readonly className?: string;
+  readonly disabled?: boolean;
+  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
-type ButtonBackInterface = React.ComponentClass<ButtonBackProps>
+type ButtonBackInterface = React.ComponentClass<ButtonBackProps>;
 /**
  * A button for moving the slider backwards. Backwards on a horizontal carousel means "move to the left". Backwards on a vertical carousel means "move to the top". The slider will traverse an amount of slides determined by the step property of CarouselProvider.
  */
-declare const ButtonBack: ButtonBackInterface
-
-
+declare const ButtonBack: ButtonBackInterface;
 
 interface ButtonLastProps {
-  readonly children: React.ReactChild
-  readonly className?: string
-  readonly disabled?: boolean
-  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly children: React.ReactChild;
+  readonly className?: string;
+  readonly disabled?: boolean;
+  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
-type ButtonLastInterface = React.ComponentClass<ButtonLastProps>
+type ButtonLastInterface = React.ComponentClass<ButtonLastProps>;
 /**
  * Moves the slider to the end of the slides (totalSlides - visibleSlides).
  */
-declare const ButtonLast: ButtonLastInterface
-
-
+declare const ButtonLast: ButtonLastInterface;
 
 interface ButtonFirstProps {
-  readonly children: React.ReactChild
-  readonly className?: string
-  readonly disabled?: boolean
-  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly children: React.ReactChild;
+  readonly className?: string;
+  readonly disabled?: boolean;
+  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
-type ButtonFirstInterface = React.ComponentClass<ButtonFirstProps>
+type ButtonFirstInterface = React.ComponentClass<ButtonFirstProps>;
 /**
  * Moves the slider to the beginning of the slides.
  */
-declare const ButtonFirst: ButtonLastInterface
-
-
+declare const ButtonFirst: ButtonLastInterface;
 
 interface ButtonPlayProps {
-  readonly childrenPaused?: React.ReactNode
-  readonly childrenPlaying?: React.ReactNode
-  readonly disabled?: boolean
-  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void
+  readonly childrenPaused?: React.ReactNode;
+  readonly childrenPlaying?: React.ReactNode;
+  readonly disabled?: boolean;
+  readonly onClick?: (ev?: React.SyntheticEvent<HTMLButtonElement>) => void;
 }
-type ButtonPlayInterface = React.ComponentClass<ButtonPlayProps>
+type ButtonPlayInterface = React.ComponentClass<ButtonPlayProps>;
 /**
  * Pressing this button causes the slides to automatically advance by CarouselProvider's step property after an interval determined by CarouselProvider's interval property.
  */
-declare const ButtonPlay: ButtonPlayInterface
+declare const ButtonPlay: ButtonPlayInterface;
 
 export {
   ButtonBack,
@@ -195,4 +175,4 @@ export {
   ButtonLastProps,
   ButtonFirstProps,
   ButtonPlayProps
-}
+};


### PR DESCRIPTION
What:

Removing the role='option' from the root HTML element for each slide so that they have the intrinsic ARIA role for li elements, i.e. listitem.

Context: https://jira.rallyhealth.com/browse/RP-9

Why:

The "option" role is not accurate per how we use the carousel.